### PR TITLE
Add NA for NULL values in rowDataToDF (hopefull fixes #3)

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -147,10 +147,13 @@ rowDataToDF <- function(rows, type = c("aggregated", "full")){
 
             # step 4: adding individual responses
             for (var in response.vars) {
-                 responses <- unlist(rows[[i]][[var]]$res)
+                responses <- unlist(rows[[i]][[var]]$res)
                 # if no responses, add missing values
                 if (length(responses) == 1 && is.na(responses)) {
                     df[[i]][,var] <- responses
+                }
+                if (is.null(responses)) {
+                  df[[i]][,var] <- NA
                 }
                 # if single response for each unit, then we can just add
                 if (length(responses) == codings) {


### PR DESCRIPTION
rowDataToDF(.., type="full") had a check for results that are NA,
but it seems crowdflower uses NULL if a variable is not used at all in a row.
So, add a check for NULL as well.

(PS: I tried running the unit tests, but they gave a syntax error (missing parenthesis on L107), but even after fixing that I get errors that don't seem related to my change)